### PR TITLE
Add CGB color correction

### DIFF
--- a/include/core/device/PictureProcessingUnit.hpp
+++ b/include/core/device/PictureProcessingUnit.hpp
@@ -259,6 +259,7 @@ namespace Core {
                 OBPI _OBPI;
 
                 bool emulateWindowLineCounter;
+                bool correctColors;
 
                 uint16_t physicalAddressForAddress(uint16_t address) const;
 
@@ -281,7 +282,7 @@ namespace Core {
 
                 std::vector<Shinobu::Frontend::OpenGL::Vertex> getBackgroundTileByIndex(uint16_t index, BackgroundMapAttributes attributes) const;
             public:
-                Processor(Common::Logs::Level logLevel, bool emulateWindowLineCounter, std::unique_ptr<Core::Device::Interrupt::Controller> &interrupt, std::unique_ptr<Shinobu::Frontend::Palette::Selector> &paletteSelector, std::unique_ptr<Core::Device::DirectMemoryAccess::Controller> &DMAController);
+                Processor(Common::Logs::Level logLevel, bool emulateWindowLineCounter, bool correctColors, std::unique_ptr<Core::Device::Interrupt::Controller> &interrupt, std::unique_ptr<Shinobu::Frontend::Palette::Selector> &paletteSelector, std::unique_ptr<Core::Device::DirectMemoryAccess::Controller> &DMAController);
                 ~Processor();
 
                 void setRenderer(Shinobu::Frontend::Renderer *renderer);

--- a/include/shinobu/Configuration.hpp
+++ b/include/shinobu/Configuration.hpp
@@ -33,6 +33,7 @@ namespace Shinobu {
             bool windowLineCounter;
             std::string dmgBootstrapROM;
             std::string cgbBootstrapROM;
+            bool colorCorrection;
 
             Manager();
         public:
@@ -59,6 +60,7 @@ namespace Shinobu {
             bool shouldEmulateWindowLineCounter() const;
             std::string DMGBootstrapROM() const;
             std::string CGBBootstrapROM() const;
+            bool shouldCorrectColors() const;
             void setupConfigurationFile() const;
             void loadConfiguration();
         };

--- a/src/shinobu/Configuration.cpp
+++ b/src/shinobu/Configuration.cpp
@@ -122,6 +122,10 @@ std::string Configuration::Manager::CGBBootstrapROM() const {
     return cgbBootstrapROM;
 }
 
+bool Configuration::Manager::shouldCorrectColors() const {
+    return colorCorrection;
+}
+
 void Configuration::Manager::setupConfigurationFile() const {
     std::ifstream file = std::ifstream(filePath);
     if (file.good()) {
@@ -145,6 +149,7 @@ void Configuration::Manager::setupConfigurationFile() const {
     emulationConfiguration["windowLineCounter"] = "true";
     emulationConfiguration["CGBBootstrapROM"] = "CGB_ROM.BIN";
     emulationConfiguration["DMGBootstrapROM"] = "DMG_ROM.BIN";
+    emulationConfiguration["colorCorrection"] = "true";
     Yaml::Node logConfiguration = Yaml::Node();
     Yaml::Node &logConfigurationRef = logConfiguration;
     logConfigurationRef["CPU"] = "NOLOG";
@@ -193,5 +198,6 @@ void Configuration::Manager::loadConfiguration() {
     windowLineCounter = configuration["emulation"]["windowLineCounter"].As<bool>();
     dmgBootstrapROM = configuration["emulation"]["DMGBootstrapROM"].As<std::string>();
     cgbBootstrapROM = configuration["emulation"]["CGBBootstrapROM"].As<std::string>();
+    colorCorrection = configuration["emulation"]["colorCorrection"].As<bool>();
     std::filesystem::remove(Common::Logs::filePath);
 }

--- a/src/shinobu/Emulator.cpp
+++ b/src/shinobu/Emulator.cpp
@@ -31,7 +31,7 @@ Emulator::Emulator() : logger(Common::Logs::Level::Message, ""), currentFrameCyc
 
     interrupt = std::make_unique<Core::Device::Interrupt::Controller>(configurationManager->interruptLogLevel());
     DMA = std::make_unique<Core::Device::DirectMemoryAccess::Controller>(configurationManager->DMALogLevel());
-    PPU = std::make_unique<Core::Device::PictureProcessingUnit::Processor>(configurationManager->PPULogLevel(), configurationManager->shouldEmulateWindowLineCounter(), interrupt, paletteSelector, DMA);
+    PPU = std::make_unique<Core::Device::PictureProcessingUnit::Processor>(configurationManager->PPULogLevel(), configurationManager->shouldEmulateWindowLineCounter(), configurationManager->shouldCorrectColors(), interrupt, paletteSelector, DMA);
 
     switch (frontend) {
     case Shinobu::Frontend::Kind::PPU:


### PR DESCRIPTION
Implementation taken from [byuu.net](https://byuu.net/video/color-emulation/). No known author. 

The Legend of Zelda: Link's Awakening (1993) title screen:

|Original|Corrected|
|---------------------------------------------|----------------------------------------------|
|![Screenshot from 2020-09-05 20-51-35](https://user-images.githubusercontent.com/346590/92311890-9969ec00-efbb-11ea-8e3a-4b0227c724d1.png)|![Screenshot from 2020-09-05 20-52-01](https://user-images.githubusercontent.com/346590/92311893-a1c22700-efbb-11ea-907f-41b272ad83ae.png)|