### PR TITLE
Add LY=WY trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ audio:
 emulation:
   CGBBootstrapROM: CGB_ROM.BIN # Relative path to CGB bootstrap ROM file, required
   DMGBootstrapROM: DMG_ROM.BIN # Relative path to DMG bootstrap ROM file, optional
+  colorCorrection: true # Enable color correction
   overrideCGB: false # Use DMG emulation whenever possible
-  windowLineCounter: true # See know issues section for a detailed explanation of this
 frontend:
   kind: SDL # Default: SDL, Available: Perf (shows performance metrics), PPU (show VRAM state)
 log: # Logging configuration (log levels: NOLOG, MSG, WAR)
@@ -83,7 +83,6 @@ Gamepad support is implemented by [`SDL_GameController` API](https://wiki.libsdl
 * Scanline rendering: the PPU emulation is driven by a scanline renderer, LCD timing effects are not working and games like Prehistorik Man won't run correctly.
 * Cartridge supported: MBC1 (RAM+BATTERY), MBC3 (RAM+BATTERY+TIMER), MBC5 (RAM+BATTERY), everything else won't run at all.
 * Game Boy Color emulation **requires** a bootstrap ROM.
-* The OpenGL renderer can be slow in some integrated graphic cards.
 
 ## Acknowledgments
 

--- a/include/core/device/PictureProcessingUnit.hpp
+++ b/include/core/device/PictureProcessingUnit.hpp
@@ -259,7 +259,6 @@ namespace Core {
                 std::array<uint8_t, 0x40> objectPaletteData;
                 OBPI _OBPI;
 
-                bool emulateWindowLineCounter;
                 bool correctColors;
 
                 uint16_t physicalAddressForAddress(uint16_t address) const;
@@ -283,7 +282,7 @@ namespace Core {
 
                 std::vector<Shinobu::Frontend::OpenGL::Vertex> getBackgroundTileByIndex(uint16_t index, BackgroundMapAttributes attributes) const;
             public:
-                Processor(Common::Logs::Level logLevel, bool emulateWindowLineCounter, bool correctColors, std::unique_ptr<Core::Device::Interrupt::Controller> &interrupt, std::unique_ptr<Shinobu::Frontend::Palette::Selector> &paletteSelector, std::unique_ptr<Core::Device::DirectMemoryAccess::Controller> &DMAController);
+                Processor(Common::Logs::Level logLevel, bool correctColors, std::unique_ptr<Core::Device::Interrupt::Controller> &interrupt, std::unique_ptr<Shinobu::Frontend::Palette::Selector> &paletteSelector, std::unique_ptr<Core::Device::DirectMemoryAccess::Controller> &DMAController);
                 ~Processor();
 
                 void setRenderer(Shinobu::Frontend::Renderer *renderer);

--- a/include/core/device/PictureProcessingUnit.hpp
+++ b/include/core/device/PictureProcessingUnit.hpp
@@ -240,6 +240,7 @@ namespace Core {
                 uint8_t windowYPosition;
                 WindowXPosition windowXPosition;
                 uint8_t windowLineCounter;
+                bool windowYPositionTrigger;
                 uint32_t steps;
                 uint8_t interruptConditions;
 

--- a/include/shinobu/Configuration.hpp
+++ b/include/shinobu/Configuration.hpp
@@ -30,7 +30,6 @@ namespace Shinobu {
             int scale;
             int palette;
             bool overrideCGBFlag;
-            bool windowLineCounter;
             std::string dmgBootstrapROM;
             std::string cgbBootstrapROM;
             bool colorCorrection;
@@ -57,7 +56,6 @@ namespace Shinobu {
             int overlayScale() const;
             int paletteIndex() const;
             bool shouldOverrideCGBFlag() const;
-            bool shouldEmulateWindowLineCounter() const;
             std::string DMGBootstrapROM() const;
             std::string CGBBootstrapROM() const;
             bool shouldCorrectColors() const;

--- a/src/core/device/PictureProcessingUnit.cpp
+++ b/src/core/device/PictureProcessingUnit.cpp
@@ -33,6 +33,7 @@ Processor::Processor(Common::Logs::Level logLevel,
                                                                                                      windowYPosition(),
                                                                                                      windowXPosition(),
                                                                                                      windowLineCounter(),
+                                                                                                     windowYPositionTrigger(),
                                                                                                      steps(),
                                                                                                      interruptConditions(),
                                                                                                      renderer(nullptr),
@@ -222,6 +223,7 @@ void Processor::step(uint8_t cycles) {
             renderer->update();
             scanlines.clear();
             windowLineCounter = 0;
+            windowYPositionTrigger = false;
         }
         if (LY >= TotalScanlines) {
             LY = 0;
@@ -401,7 +403,7 @@ std::pair<uint8_t, BackgroundMapAttributes> Processor::getColorIndexForBackgroun
         currentWindowY = LY - windowYPosition;
     }
     if (control.windowDisplayEnable) {
-        if (LY >= windowYPosition && screenPositionX >= windowXPosition.position()) {
+        if (windowYPositionTrigger && screenPositionX >= windowXPosition.position()) {
             addressStart = windowMapAddressStart;
             tileIndexInMap = ((screenPositionX - windowXPosition.position()) / VRAMTileDataSide) + (currentWindowY / VRAMTileDataSide) * VRAMTileBackgroundMapSide;
             drawWindow = true;
@@ -662,6 +664,9 @@ void Processor::CGB_renderScanline() {
 }
 
 void Processor::renderScanline() {
+    if (LY == windowYPosition) {
+        windowYPositionTrigger = true;
+    }
     if (cgbFlag != Core::ROM::CGBFlag::DMG) {
         CGB_renderScanline();
     } else {

--- a/src/core/device/PictureProcessingUnit.cpp
+++ b/src/core/device/PictureProcessingUnit.cpp
@@ -11,7 +11,6 @@ using namespace Core::Device::PictureProcessingUnit;
 using namespace Shinobu::Frontend::Palette;
 
 Processor::Processor(Common::Logs::Level logLevel,
-                     bool emulateWindowLineCounter,
                      bool correctColors,
                      std::unique_ptr<Core::Device::Interrupt::Controller> &interrupt,
                      std::unique_ptr<Shinobu::Frontend::Palette::Selector> &paletteSelector,
@@ -47,7 +46,6 @@ Processor::Processor(Common::Logs::Level logLevel,
                                                                                                      _BGPI(),
                                                                                                      objectPaletteData(),
                                                                                                      _OBPI(),
-                                                                                                     emulateWindowLineCounter(emulateWindowLineCounter),
                                                                                                      correctColors(correctColors) {
 
 }
@@ -399,9 +397,6 @@ std::pair<uint8_t, BackgroundMapAttributes> Processor::getColorIndexForBackgroun
     uint16_t tileIndexInMap = (screenPositionXWithScroll / VRAMTileDataSide) + (screenPositionYWithScroll / VRAMTileDataSide) * VRAMTileBackgroundMapSide;
     uint32_t addressStart = backgroundMapAddressStart;
     uint8_t currentWindowY = windowLineCounter;
-    if (!emulateWindowLineCounter) {
-        currentWindowY = LY - windowYPosition;
-    }
     if (control.windowDisplayEnable) {
         if (windowYPositionTrigger && screenPositionX >= windowXPosition.position()) {
             addressStart = windowMapAddressStart;

--- a/src/shinobu/Configuration.cpp
+++ b/src/shinobu/Configuration.cpp
@@ -22,9 +22,9 @@ Configuration::Manager::Manager() : logger(Common::Logs::Logger(Common::Logs::Le
     scale(),
     palette(),
     overrideCGBFlag(),
-    windowLineCounter(true),
     dmgBootstrapROM(),
-    cgbBootstrapROM()
+    cgbBootstrapROM(),
+    colorCorrection(true)
 {
 
 }
@@ -110,10 +110,6 @@ bool Configuration::Manager::shouldOverrideCGBFlag() const {
     return overrideCGBFlag;
 }
 
-bool Configuration::Manager::shouldEmulateWindowLineCounter() const {
-    return windowLineCounter;
-}
-
 std::string Configuration::Manager::DMGBootstrapROM() const {
     return dmgBootstrapROM;
 }
@@ -146,7 +142,6 @@ void Configuration::Manager::setupConfigurationFile() const {
     Yaml::Node emulationConfiguration = Yaml::Node();
     Yaml::Node &emulationConfigurationRef = emulationConfiguration;
     emulationConfiguration["overrideCGB"] = "false";
-    emulationConfiguration["windowLineCounter"] = "true";
     emulationConfiguration["CGBBootstrapROM"] = "CGB_ROM.BIN";
     emulationConfiguration["DMGBootstrapROM"] = "DMG_ROM.BIN";
     emulationConfiguration["colorCorrection"] = "true";
@@ -195,7 +190,6 @@ void Configuration::Manager::loadConfiguration() {
     scale = configuration["video"]["overlayScale"].As<int>();
     palette = configuration["video"]["palette"].As<int>();
     overrideCGBFlag = configuration["emulation"]["overrideCGB"].As<bool>();
-    windowLineCounter = configuration["emulation"]["windowLineCounter"].As<bool>();
     dmgBootstrapROM = configuration["emulation"]["DMGBootstrapROM"].As<std::string>();
     cgbBootstrapROM = configuration["emulation"]["CGBBootstrapROM"].As<std::string>();
     colorCorrection = configuration["emulation"]["colorCorrection"].As<bool>();

--- a/src/shinobu/Emulator.cpp
+++ b/src/shinobu/Emulator.cpp
@@ -31,7 +31,7 @@ Emulator::Emulator() : logger(Common::Logs::Level::Message, ""), currentFrameCyc
 
     interrupt = std::make_unique<Core::Device::Interrupt::Controller>(configurationManager->interruptLogLevel());
     DMA = std::make_unique<Core::Device::DirectMemoryAccess::Controller>(configurationManager->DMALogLevel());
-    PPU = std::make_unique<Core::Device::PictureProcessingUnit::Processor>(configurationManager->PPULogLevel(), configurationManager->shouldEmulateWindowLineCounter(), configurationManager->shouldCorrectColors(), interrupt, paletteSelector, DMA);
+    PPU = std::make_unique<Core::Device::PictureProcessingUnit::Processor>(configurationManager->PPULogLevel(), configurationManager->shouldCorrectColors(), interrupt, paletteSelector, DMA);
 
     switch (frontend) {
     case Shinobu::Frontend::Kind::PPU:


### PR DESCRIPTION
> @Powerlated:  if LY=WY at the beginning of the scanline, then the WY trigger is activated, meaning the window is now eligible for being drawn, and the trigger is reset at Vblank.

LY=WY trigger tested with [Powerlated/TurtleTests](https://github.com/Powerlated/TurtleTests).