### PR TITLE
Add integerScale to configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ log: # Logging configuration (log levels: NOLOG, MSG, WAR)
   timer: NOLOG
 video:
   fullscreen: false # Desktop fullscreen startup
+  integerScale: false # Enable to force integer scaling, helps with shaders on high density displays
   overlayScale: 0 # Enable overlay with 1 and increase this if it's is too small
   palette: 0 # Select a custom palette for DMG emulation (10 available)
   screenDoorEffect: false # Emulate Game Boy LCD screen door effect

--- a/include/shinobu/Configuration.hpp
+++ b/include/shinobu/Configuration.hpp
@@ -34,6 +34,7 @@ namespace Shinobu {
             std::string cgbBootstrapROM;
             bool colorCorrection;
             bool screenDoorEffect;
+            bool forceIntegerScale;
 
             Manager();
         public:
@@ -61,6 +62,7 @@ namespace Shinobu {
             std::string CGBBootstrapROM() const;
             bool shouldCorrectColors() const;
             bool shouldEmulateScreenDoorEffect() const;
+            bool shouldForceIntegerScale() const;
             void setupConfigurationFile() const;
             void loadConfiguration();
         };

--- a/src/shinobu/Configuration.cpp
+++ b/src/shinobu/Configuration.cpp
@@ -24,7 +24,9 @@ Configuration::Manager::Manager() : logger(Common::Logs::Logger(Common::Logs::Le
     overrideCGBFlag(),
     dmgBootstrapROM(),
     cgbBootstrapROM(),
-    colorCorrection(true)
+    colorCorrection(true),
+    screenDoorEffect(false),
+    forceIntegerScale(false)
 {
 
 }
@@ -126,6 +128,10 @@ bool Configuration::Manager::shouldEmulateScreenDoorEffect() const {
     return screenDoorEffect;
 }
 
+bool Configuration::Manager::shouldForceIntegerScale() const {
+    return forceIntegerScale;
+}
+
 void Configuration::Manager::setupConfigurationFile() const {
     std::ifstream file = std::ifstream(filePath);
     if (file.good()) {
@@ -138,6 +144,7 @@ void Configuration::Manager::setupConfigurationFile() const {
     videoConfigurationRef["overlayScale"] = "0";
     videoConfigurationRef["palette"] = "0";
     videoConfigurationRef["screenDoorEffect"] = "false";
+    videoConfigurationRef["integerScale"] = "false";
     Yaml::Node audioConfiguration = Yaml::Node();
     Yaml::Node &audioConfigurationRef = audioConfiguration;
     audioConfigurationRef["mute"] = "false";
@@ -195,6 +202,7 @@ void Configuration::Manager::loadConfiguration() {
     scale = configuration["video"]["overlayScale"].As<int>();
     palette = configuration["video"]["palette"].As<int>();
     screenDoorEffect = configuration["video"]["screenDoorEffect"].As<bool>();
+    forceIntegerScale = configuration["video"]["integerScale"].As<bool>();
     overrideCGBFlag = configuration["emulation"]["overrideCGB"].As<bool>();
     dmgBootstrapROM = configuration["emulation"]["DMGBootstrapROM"].As<std::string>();
     cgbBootstrapROM = configuration["emulation"]["CGBBootstrapROM"].As<std::string>();

--- a/src/shinobu/Emulator.cpp
+++ b/src/shinobu/Emulator.cpp
@@ -24,8 +24,18 @@ Emulator::Emulator() : logger(Common::Logs::Level::Message, ""), currentFrameCyc
     SDL_DisplayMode displayMode;
     Frontend::SDL2::handleSDL2Error(SDL_GetDesktopDisplayMode(0, &displayMode), logger);
 
-    int heigth = displayMode.h / 2;
-    int width = (float)heigth * 1.11;
+    int width, heigth;
+    if (configurationManager->shouldForceIntegerScale()) {
+        int maxVerticalRatio = (displayMode.h / 2) / VerticalResolution;
+        int maxHorizontalRatio = (displayMode.w / 2) / HorizontalResolution;
+        int ratio = maxVerticalRatio > maxHorizontalRatio ? maxVerticalRatio : maxHorizontalRatio;
+        heigth = VerticalResolution * ratio;
+        width = HorizontalResolution * ratio;
+    } else {
+        heigth = displayMode.h / 2;
+        width = (float)heigth * 1.11;
+    }
+
     window = std::make_unique<Shinobu::Frontend::SDL2::Window>("しのぶ", width, heigth, configurationManager->shouldLaunchFullscreen());
     setupOpenGL();
 


### PR DESCRIPTION
The initial window dimensions are used for the projection matrix during window resizing events, so any scale set during the window initialization will be preserved.

Integer scale helps with shader effects (like the one introduced in https://github.com/UnsafePointer/shinobu/pull/4) on high density displays.  