### PR TITLE
Add SDL_Joystick support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ emulation:
   overrideCGB: false # Use DMG emulation whenever possible
 frontend:
   kind: SDL # Default: SDL, Available: PPU (show VRAM state)
+input:
+  controllerName: Bluetooth # For non-Xbox-like controllers only
 log: # Logging configuration (log levels: NOLOG, MSG, WAR)
   CPU: NOLOG
   DMA: NOLOG
@@ -72,7 +74,7 @@ video:
 
 ![keyboard.png](/images/keyboard.png)
 
-Gamepad support is implemented by [`SDL_GameController` API](https://wiki.libsdl.org/CategoryGameController) (Xbox-type controllers). Only the Game Boy buttons and DMG palette selection are mapped.
+Gamepad support is implemented by [`SDL_GameController` API](https://wiki.libsdl.org/CategoryGameController) (Xbox-type controllers) and [`SDL_Joystick` API](https://wiki.libsdl.org/CategoryJoystick) (other type of controllers) with static bindings. Only the Game Boy buttons and DMG palette selection are mapped.
 
 ### PPU visualizer
 

--- a/include/core/device/JoypadInput.hpp
+++ b/include/core/device/JoypadInput.hpp
@@ -34,7 +34,7 @@ namespace Core {
                 Joypad joypad;
                 Shinobu::Frontend::SDL2::GameController gameController;
             public:
-                Controller(Common::Logs::Level logLevel, std::unique_ptr<Core::Device::Interrupt::Controller> &interrupt);
+                Controller(Common::Logs::Level logLevel, std::unique_ptr<Core::Device::Interrupt::Controller> &interrupt, std::string controllerName);
                 ~Controller();
 
                 uint8_t load() const;

--- a/include/shinobu/Configuration.hpp
+++ b/include/shinobu/Configuration.hpp
@@ -36,6 +36,7 @@ namespace Shinobu {
             bool screenDoorEffect;
             bool forceIntegerScale;
             std::string sentryDSN;
+            std::string controllerName;
 
             Manager();
         public:
@@ -65,6 +66,7 @@ namespace Shinobu {
             bool shouldEmulateScreenDoorEffect() const;
             bool shouldForceIntegerScale() const;
             std::string getSentryDSN() const;
+            std::string gameControllerName() const;
             void setupConfigurationFile() const;
             void loadConfiguration();
         };

--- a/include/shinobu/frontend/sdl2/GameController.hpp
+++ b/include/shinobu/frontend/sdl2/GameController.hpp
@@ -19,14 +19,16 @@ namespace Shinobu {
             class GameController {
                 Common::Logs::Logger logger;
                 SDL_GameController *controller;
+                SDL_Joystick *joystick;
 
-                bool isGameControllerButtonPressed(Button button);
-                bool isKeyboardBindingForButtonPressed(Button button);
+                bool isGameControllerButtonPressed(Button button) const;
+                bool isKeyboardBindingForButtonPressed(Button button) const;
+                bool isJoystickButtonPressed(Button button) const;
             public:
-                GameController(Common::Logs::Level logLevel);
+                GameController(Common::Logs::Level logLevel, std::string controllerName);
                 ~GameController();
 
-                bool isButtonPressed(Button button);
+                bool isButtonPressed(Button button) const;
                 bool hasGameController() const;
             };
         };

--- a/src/core/device/JoypadInput.cpp
+++ b/src/core/device/JoypadInput.cpp
@@ -5,7 +5,7 @@
 using namespace Core::Device::JoypadInput;
 using namespace Shinobu::Frontend::SDL2;
 
-Controller::Controller(Common::Logs::Level logLevel, std::unique_ptr<Core::Device::Interrupt::Controller> &interrupt) : logger(logLevel, "  [Joypad]: "), interrupt(interrupt), joypad(), gameController(Common::Logs::Level::Warning) {}
+Controller::Controller(Common::Logs::Level logLevel, std::unique_ptr<Core::Device::Interrupt::Controller> &interrupt, std::string controllerName) : logger(logLevel, "  [Joypad]: "), interrupt(interrupt), joypad(), gameController(Common::Logs::Level::Warning, controllerName) {}
 
 Controller::~Controller() {}
 

--- a/src/shinobu/Configuration.cpp
+++ b/src/shinobu/Configuration.cpp
@@ -27,7 +27,8 @@ Configuration::Manager::Manager() : logger(Common::Logs::Logger(Common::Logs::Le
     colorCorrection(true),
     screenDoorEffect(false),
     forceIntegerScale(false),
-    sentryDSN("")
+    sentryDSN(""),
+    controllerName("")
 {
 
 }
@@ -137,6 +138,10 @@ std::string Configuration::Manager::getSentryDSN() const {
     return sentryDSN;
 }
 
+std::string Configuration::Manager::gameControllerName() const {
+    return controllerName;
+}
+
 void Configuration::Manager::setupConfigurationFile() const {
     std::ifstream file = std::ifstream(filePath);
     if (file.good()) {
@@ -153,6 +158,9 @@ void Configuration::Manager::setupConfigurationFile() const {
     Yaml::Node audioConfiguration = Yaml::Node();
     Yaml::Node &audioConfigurationRef = audioConfiguration;
     audioConfigurationRef["mute"] = "false";
+    Yaml::Node inputConfiguration = Yaml::Node();
+    Yaml::Node &inputConfigurationRef = inputConfiguration;
+    inputConfigurationRef["controllerName"] = "";
     Yaml::Node frontendConfiguration = Yaml::Node();
     Yaml::Node &frontendConfigurationRef = frontendConfiguration;
     frontendConfigurationRef["kind"] = "SDL";
@@ -187,6 +195,7 @@ void Configuration::Manager::setupConfigurationFile() const {
     configurationRef["video"] = videoConfiguration;
     configurationRef["emulation"] = emulationConfigurationRef;
     configurationRef["sentry"] = sentryConfigurationRef;
+    configurationRef["input"] = inputConfigurationRef;
     Yaml::Serialize(configuration, filePath.string().c_str());
 }
 
@@ -217,5 +226,6 @@ void Configuration::Manager::loadConfiguration() {
     cgbBootstrapROM = configuration["emulation"]["CGBBootstrapROM"].As<std::string>();
     colorCorrection = configuration["emulation"]["colorCorrection"].As<bool>();
     sentryDSN = configuration["sentry"]["dsn"].As<std::string>();
+    controllerName = configuration["input"]["controllerName"].As<std::string>();
     std::filesystem::remove(Common::Logs::filePath);
 }

--- a/src/shinobu/Emulator.cpp
+++ b/src/shinobu/Emulator.cpp
@@ -59,7 +59,7 @@ Emulator::Emulator() : logger(Common::Logs::Level::Message, ""), currentFrameCyc
     sound = std::make_unique<Core::Device::Sound::Controller>(configurationManager->soundLogLevel(), isMuted);
     sound->setSampleRate(SampleRate);
     timer = std::make_unique<Core::Device::Timer::Controller>(configurationManager->timerLogLevel(), interrupt);
-    joypad = std::make_unique<Core::Device::JoypadInput::Controller>(configurationManager->joypadLogLevel(), interrupt);
+    joypad = std::make_unique<Core::Device::JoypadInput::Controller>(configurationManager->joypadLogLevel(), interrupt, configurationManager->gameControllerName());
     cartridge = std::make_unique<Core::ROM::Cartridge>(configurationManager->ROMLogLevel(), configurationManager->shouldOverrideCGBFlag());
     memoryController = std::make_unique<Core::Memory::Controller>(configurationManager->memoryLogLevel(), cartridge, PPU, sound, interrupt, timer, joypad, DMA);
     processor = std::make_unique<Core::CPU::Processor>(configurationManager->CPULogLevel(), memoryController, interrupt);
@@ -168,11 +168,11 @@ void Emulator::handleSDLEvent(SDL_Event event) {
     }
     if (joypad->hasGameController()) {
         // TODO: Use Controller events API instead of Joypad
-        if (event.type == SDL_JOYBUTTONDOWN && event.button.which == 260) {
+        if (event.type == SDL_JOYBUTTONDOWN && (event.button.which == 260 || event.button.which == 262)) {
             paletteSelector->backwardSelector();
             return;
         }
-        if (event.type == SDL_JOYBUTTONDOWN && event.button.which == 261) {
+        if (event.type == SDL_JOYBUTTONDOWN && (event.button.which == 261 || event.button.which == 263)) {
             paletteSelector->forwardSelector();
             return;
         }


### PR DESCRIPTION
Support for non-Xbox-like controllers using the [`SDL_Joystick` API](https://wiki.libsdl.org/CategoryJoystick), like the 8BitDo SN30 controller family.